### PR TITLE
library dependencies added to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,4 @@
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
+lib_deps = JsonStreamingParser, ESP8266_SSD1306, WifiManager


### PR DESCRIPTION
fixes goergch/ESP8266_SegregatedWitnessDisplay#1 and goergch/ESP8266_SegregatedWitnessDisplay#2